### PR TITLE
bit clunky in some places, but works perfectly (commands in desc)

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -98,5 +98,11 @@ class Rolegroups:
     cooldown_time = int(config["Rolegroups"]["CooldownTime"])
     role_count_limit = int(config["Rolegroups"]["RoleCountLimit"])
 
+
 class EmojiSurvey:
     channel_id = int(config["EmojiSurvey"]["ChannelID"])
+
+
+class Christmas_Competition:
+    leaderboard_id = config["Christmas"]["LeaderboardId"]
+    year = config["Christmas"]["Event"]

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -3,7 +3,7 @@
 # formatting - use Notepad++ or a code editor like Visual Studio Code.
 [Bot]
 # all extensions to be loaded at startup. Errors loading extensions will result in termination of the entire bot
-Extensions = autoreactions bouncer misc modmail ranks reputation warnings
+Extensions = autoreactions bouncer misc modmail ranks reputation warnings christmas_competition
 
 # This is your Discord bot account token.
 # Find your bot's token here: https://discordapp.com/developers/applications/me/
@@ -139,3 +139,7 @@ RoleCountLimit = 5
 
 [EmojiSurvey]
 ChannelID = 155149108183695360
+
+[Christmas]
+LeaderboardId = 422654
+Event = 2021

--- a/db_classes/PGChristmasDB.py
+++ b/db_classes/PGChristmasDB.py
@@ -1,0 +1,113 @@
+import asyncio
+import logging
+import asyncpg
+
+from config.config import PostGres as pg_config
+
+creation = (
+    """
+    CREATE TABLE IF NOT EXISTS aoc_users (
+        discord_id BIGINT PRIMARY KEY,
+        aoc_name VARCHAR UNIQUE
+    )
+    """,
+    # bit clunky to have a separate table for this that'll only ever have 1 row, but whatever
+    """
+    CREATE TABLE IF NOT EXISTS aoc_cookie (
+        cookie VARCHAR
+    )
+    """
+)
+
+deletion = (
+    """
+    DROP TABLE IF EXISTS aoc_users
+    """,
+    """
+    DROP TABLE IF EXISTS aoc_cookie
+    """
+)
+
+logger = logging.getLogger("Referee")
+
+class PGChristmasDB:
+    def __init__(self):
+        self.pool = asyncpg.create_pool(
+            host=pg_config.PG_Host,
+            database=pg_config.PG_Database,
+            user=pg_config.PG_User,
+            password=pg_config.PG_Password
+        )
+
+        asyncio.get_event_loop().run_until_complete(self.create_tables())
+
+    async def close(self):
+        """
+        Closes the connection to the db
+        """
+        await self.pool.close()
+
+    async def create_tables(self):
+        """
+        Creates the tables in the db if they don't exist.
+        This is called on every startup
+        """
+        self.pool = await self.pool
+        async with self.pool.acquire() as con:
+            for query in creation:
+                await con.execute(query)
+
+
+    async def update_cookie(self, cookie: str):
+        delete = "DELETE FROM aoc_cookie"
+        insert = "INSERT INTO aoc_cookie(cookie) VALUES ($1)"
+        async with self.pool.acquire() as con:
+            await con.execute(delete)
+            await con.execute(insert, cookie)
+
+    async def get_cookie(self):
+        query = "SELECT * FROM aoc_cookie"
+        async with self.pool.acquire() as con:
+            results = await con.fetch(query)
+
+        return [r["cookie"] for r in results][0]
+
+
+    async def add_user(self, aoc_name: str, discord_id: int):
+        insert = (
+            "INSERT into aoc_users(aoc_name, discord_id) VALUES($1, $2)"
+        )
+        async with self.pool.acquire() as con:
+            await con.execute(insert, aoc_name, discord_id)
+
+    async def update_user(self, aoc_name: str, discord_id: int):
+        update = "UPDATE aoc_users SET aoc_name=$1 WHERE discord_id=$2"
+        async with self.pool.acquire() as con:
+            await con.execute(update, aoc_name, discord_id)
+
+    async def get_all_users(self):
+        query = "SELECT * FROM aoc_users"
+        async with self.pool.acquire() as con:
+            results = await con.fetch(query)
+
+        return [(row["aoc_name"], row["discord_id"]) for row in results]
+
+    async def get_user(self, aoc_name: str, discord_id: int):
+        if aoc_name is None and discord_id is None:
+            return None
+        if aoc_name is not None and discord_id is not None:
+            return None
+        if aoc_name is None:
+            # discord_id is not None, we want aoc_name
+            query = "SELECT aoc_name, discord_id FROM aoc_users WHERE discord_id = $1"
+        else:
+            # aoc_name is not None, we want discord_id
+            query = "SELECT aoc_name, discord_id FROM aoc_users WHERE aoc_name = $1"
+
+        async with self.pool.acquire() as con:
+            results = await con.fetch(query, discord_id if aoc_name is None else aoc_name)
+
+        result = [(row["aoc_name"], row["discord_id"]) for row in results]
+        if len(result) == 0:
+            return None
+        return result[0]

--- a/extensions/christmas_competition.py
+++ b/extensions/christmas_competition.py
@@ -1,0 +1,131 @@
+import asyncio
+import logging
+
+import aiohttp
+import discord
+from discord.ext import commands
+
+from datetime import datetime, timedelta
+
+from config.config import Christmas_Competition as config, Timeouts
+
+from Referee import can_kick
+from db_classes.PGChristmasDB import PGChristmasDB
+from utils import emoji
+
+logger = logging.getLogger("Referee")
+
+
+class ChristmasCompetition(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.db = PGChristmasDB()
+        self.lb_data = None
+        self.last_updated_lb = datetime.fromtimestamp(0)
+
+    @commands.command(name="set_cookie", hidden=True)
+    @can_kick()
+    async def UpdateAocCookie(self, ctx: commands.Context, cookie: str):
+        await self.db.update_cookie(cookie)
+
+    @commands.command(name="test_cookie", hidden=True)
+    @can_kick()
+    async def TestAocCookie(self, ctx: commands.Context):
+        url = 'https://adventofcode.com/' + config.year + '/leaderboard/private/view/' + config.leaderboard_id + '.json'
+        cookies = {'session': await self.db.get_cookie()}
+        async with aiohttp.ClientSession(cookies=cookies) as session:
+            async with session.get(url) as resp:
+                await ctx.reply(resp.status)
+
+    @commands.command(name="aoc", aliases=["register", "egister"], hidden=True)
+    async def Register(self, ctx: commands.Context, name: str):
+        if await self.db.get_user(None, ctx.message.author.id) is not None:
+            await ctx.message.channel.send("You are already registered.", delete_after=Timeouts.short)
+            return
+
+        message = await ctx.reply("Is " + name + " Your AoC name? If so, react with " + emoji.thumbs_up)
+        await message.add_reaction(emoji.thumbs_up)
+        await message.add_reaction(emoji.trashcan)
+
+        def check(_reaction: discord.Reaction, _user):
+            return _reaction.message.id == message.id and _user == ctx.message.author and str(_reaction.emoji) in [
+                emoji.trashcan, emoji.thumbs_up]
+
+        try:
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=Timeouts.mid, check=check)
+        except asyncio.TimeoutError:
+            await ctx.message.channel.send("AoC name wasn't confirmed, cancelling.", delete_after=Timeouts.short)
+        else:
+            if reaction.emoji == emoji.thumbs_up:
+                await self.db.add_user(name.lower(), ctx.message.author.id)
+                await ctx.message.channel.send("AoC name confirmed, saving...", delete_after=Timeouts.short)
+        finally:
+            await message.delete()
+
+    @commands.command(name="aoc_update", hidden=True)
+    async def Update(self, ctx: commands.Context, name: str):
+        message = await ctx.reply("Is " + name + " Your AoC name? If so, react with " + emoji.thumbs_up)
+        await message.add_reaction(emoji.thumbs_up)
+        await message.add_reaction(emoji.trashcan)
+
+        def check(_reaction: discord.Reaction, _user):
+            return _reaction.message.id == message.id and _user == ctx.message.author and str(_reaction.emoji) in [
+                emoji.trashcan, emoji.thumbs_up]
+
+        try:
+            reaction, user = await self.bot.wait_for('reaction_add', timeout=Timeouts.mid, check=check)
+        except asyncio.TimeoutError:
+            await ctx.message.channel.send("AoC name wasn't confirmed, cancelling.", delete_after=Timeouts.short)
+        else:
+            if reaction.emoji == emoji.thumbs_up:
+                await self.db.update_user(name.lower(), ctx.message.author.id)
+                await ctx.message.channel.send("AoC name confirmed, saving...", delete_after=Timeouts.short)
+        finally:
+            await message.delete()
+
+
+    async def TryUpdateLeaderboardData(self):
+        if (datetime.now() - self.last_updated_lb).seconds <= 1000:
+            return
+
+        self.last_updated_lb = datetime.now()
+
+        url = 'https://adventofcode.com/' + config.year + '/leaderboard/private/view/' + config.leaderboard_id + '.json'
+        cookies = {'session': await self.db.get_cookie()}
+        async with aiohttp.ClientSession(cookies=cookies) as session:
+            async with session.get(url) as resp:
+                self.lb_data = await resp.json()
+
+    @commands.command(name="notjoined", hidden=True)
+    @can_kick()
+    async def NotOnLeaderboard(self, ctx: commands.Context):
+        await self.TryUpdateLeaderboardData()
+        registered = await self.db.get_all_users()
+        in_leaderboard = []
+        for member_id in self.lb_data["members"]:
+            in_leaderboard += [self.lb_data["members"][member_id]["name"]]
+
+        out = "__**joined via discord, but not in leaderboard**__\n"
+
+        for user in registered:
+            if user[0] not in in_leaderboard:
+                out += user[0] + " (discord: <@" + str(user[1]) + ">)\n"
+        out += "__**joined leaderboard, but not via discord**__\n"
+        for user in in_leaderboard:
+            if not any(u[0] == user for u in registered):
+                out += user + "\n"
+
+        await ctx.reply(out)
+
+    @commands.command(name="whois_discord", hidden=True)
+    @can_kick()
+    async def AoC_WhoIs(self, ctx: commands.Context, *, subject: discord.Member):
+        await ctx.reply(await self.db.get_user(None, subject.id))
+
+    @commands.command(name="whois_aoc", hidden=True)
+    @can_kick()
+    async def AoC_WhoIs2(self, ctx: commands.Context, subject: str):
+        await ctx.reply(await self.db.get_user(subject, None))
+
+def setup(bot: commands.Bot):
+    bot.add_cog(ChristmasCompetition(bot))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 async-timeout==3.0.1
 discord.py
-asyncpg
-Pillow
+asyncpg~=0.24.0
+Pillow~=8.3.2
 numpy
-matplotlib
+matplotlib~=3.4.3
+aiohttp~=3.7.4.post0


### PR DESCRIPTION
r!set_cookie 1234 - sets the AoC session cookie
r!test_cookie - runs a simple request and replies with the status code to see if the cookie is valid
r!aoc, register, egister ichbineinNerd - registers the author's discord account with their AoC account
r!aoc_update - like above, but updates an already existing connection
r!notjoined (can_kick) - shows all the users that are either not registered on discord but are on the leaderboard, or the other way around
r!whois_discord @discord_user (can_kick) - shows AoC account linked to a given discord account
r!whois_aoc ichbineinNerd (can_kick) - shows the discord account linked to a given AoC account